### PR TITLE
Bugfix - Cannot Create Rock

### DIFF
--- a/src/components/RockForm.jsx
+++ b/src/components/RockForm.jsx
@@ -75,7 +75,7 @@ export const RockForm = ({ fetchRocks }) => {
                         <select id="type" className="form-control"
                             onChange={e => {
                                 const copy = { ...rock }
-                                copy.type_id = parseInt(e.target.value)
+                                copy.typeId = parseInt(e.target.value)
                                 updateRockProps(copy)
                             }}>
                             <option value={0}>- Select a type -</option>


### PR DESCRIPTION
### Purpose
To allow Users to properly create Rocks

### Files Changed
- Changed assignment in onChange from "type_id" to "typeId" in `RockForm.jsx`

### To Test
Fetch, setup, and run this frontned and related backend, then confirm the following
- Filling out New Rock form and submitting creates a new Rock
- Successfully creating a new Rock navigates User to the Rocks List view, which should contain the newly made Rock